### PR TITLE
Fix Exhibit error with deleted/non-public items

### DIFF
--- a/FedoraConnectorPlugin.php
+++ b/FedoraConnectorPlugin.php
@@ -252,6 +252,11 @@ SQL
     public function filterExhibitAttachmentMarkup($html, $options)
     {
         $item = $options['attachment']->getItem();
+
+        if ($item === null) {
+            return;
+        }
+
         if (fc_isFedoraStream($item)) {
             $uri  = exhibit_builder_exhibit_item_uri($item);
 


### PR DESCRIPTION
See http://omeka.org/forums/topic/omeka-view-exception-current-item-variable-has-not-been-set-to-this-view

FedoraConnector uses a filter to display the fedora bitstream in an exhibit. However, it doesn't account for the possiblity that `getItem` for an attachment might return `null`. This happens when an Item has just been deleted, but the exhibit page hasn't yet been edited again, or if a non-public item is included in an exhibit and a user without permissions is viewing it.

This simply adds a check against null to bail out early and avoid failed "current item" lookups later in the function.